### PR TITLE
Fix table name for adding 'option_code' column

### DIFF
--- a/Setup/EavSchemaSetup.php
+++ b/Setup/EavSchemaSetup.php
@@ -426,7 +426,7 @@ class EavSchemaSetup implements EavSchemaSetupInterface
         );
         $this->setup->getConnection()->createTable($optionValuesTable);
 
-        $this->installOptionCodes($optionValuesTableName);
+        $this->installOptionCodes($optionsTableName);
     }
 
     /**


### PR DESCRIPTION
Fixes #42 by updating the table that the 'option_code' column gets created on.